### PR TITLE
Removing large grok failure

### DIFF
--- a/IPS_v1_sanitized.json
+++ b/IPS_v1_sanitized.json
@@ -72,6 +72,18 @@ filter {
         
     
     }
+	    #If it contains "Group" in the message
+		
+    else if "Group \= " in [message]{
+    
+		grok {
+            match => [
+                "message", "Group \= %{GroupIP:IPORHOST}\, IP \= {IPORHOST}\, %{groupmsg:GREEDYDATA}",
+				
+            ]
+        
+        }
+    }
     
     #For actual messages that can be alerted on
     else if "Impact" in [message] and "Classification" in [message] {


### PR DESCRIPTION
Not the original code writer, so I'm taking my hand at making this stop generating tons of _grokparse failure alerts. Right now it looks like the log, "Group = [IP], IP = [IP], constructing qm hash payload" and others of that nature keep appearing. Unsure whether or not to drop them.